### PR TITLE
fix: Update license language in contributing guide

### DIFF
--- a/docs/contributing/introduction-to-contributing.md
+++ b/docs/contributing/introduction-to-contributing.md
@@ -151,4 +151,4 @@ Do you have questions? Join the conversation in our [Discord](https://discord.gg
 ## License
 
 By contributing to the OpenSauced project, you agree that your contributions will be licensed
-under the License specified in the repo you are contributing to. This can be found in the `LICENSE` file.
+under a specific License. This information can be found in the `LICENSE` file of the repo you are contributing to.

--- a/docs/contributing/introduction-to-contributing.md
+++ b/docs/contributing/introduction-to-contributing.md
@@ -151,4 +151,4 @@ Do you have questions? Join the conversation in our [Discord](https://discord.gg
 ## License
 
 By contributing to the OpenSauced project, you agree that your contributions will be licensed
-under its [MIT license](https://raw.githubusercontent.com/open-sauced/open-sauced/main/LICENSE).
+under the License specified in the repo you are contributing to. This can be found in the `LICENSE` file.

--- a/docs/contributing/introduction-to-contributing.md
+++ b/docs/contributing/introduction-to-contributing.md
@@ -151,4 +151,4 @@ Do you have questions? Join the conversation in our [Discord](https://discord.gg
 ## License
 
 By contributing to the OpenSauced project, you agree that your contributions will be licensed
-under the License specified in the repo you are contributing to. This can be found in the `LICENSE` file.
+by a specific License. This information can be found in the `LICENSE` file of the repo you are contributing to.

--- a/docs/contributing/introduction-to-contributing.md
+++ b/docs/contributing/introduction-to-contributing.md
@@ -151,4 +151,4 @@ Do you have questions? Join the conversation in our [Discord](https://discord.gg
 ## License
 
 By contributing to the OpenSauced project, you agree that your contributions will be licensed
-under a specific License. This information can be found in the `LICENSE` file of the repo you are contributing to.
+under the License specified in the repo you are contributing to. This can be found in the `LICENSE` file.


### PR DESCRIPTION
## Description

This PR updates the license language in the contributors guide to reflect the fact that different repos use different licenses. The exact language is only a suggestion and I'm happy to change it.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Fixes #139 

## Mobile & Desktop Screenshots/Recordings


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [x] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

No.

## [optional] What gif best describes this PR or how it makes you feel?

