### PR TITLE
feat: creating separate section for setting up repo with Git

### DIFF
--- a/docs/technical/resolve-merge-conflicts.md
+++ b/docs/technical/resolve-merge-conflicts.md
@@ -16,46 +16,9 @@ In literally every case it is advised _**not**_ to use the `Resolve conflicts` b
 
 The above will at best achieve a ready to merge pull request with visible inconsistencies.
 
-## Repository setup
-
-Fork and clone the project using the `gh` command line interface:
-
-```shell
-gh repo clone 0-vortex/open-sauced
-```
-
-Running `git remote -v` will output:
-
-```shell
-origin git@github.com:0-vortex/open-sauced.git (fetch)
-origin git@github.com:0-vortex/open-sauced.git (push)
-upstream git@github.com:open-sauced/open-sauced.git (fetch)
-upstream git@github.com:open-sauced/open-sauced.git (push)
-```
-
-Fork and clone the project using the `git` command line interface:
-
-```shell
-git clone git@github.com:0-vortex/open-sauced.git
-```
-
-Running `git remote -v` will output:
-
-```shell
-origin git@github.com:0-vortex/open-sauced.git (fetch)
-origin git@github.com:0-vortex/open-sauced.git (push)
-```
-
-As an additional step for this tutorial we need to add the `upstream` remote:
-
-```shell
-git remote add upstream git@github.com:open-sauced/open-sauced.git
-```
-
 ## Update
 
 First get the default branch changes:
-
 
 ```shell
 git fetch origin --recurse-submodules=no --progress --prune
@@ -67,7 +30,6 @@ git merge upstream/main --no-stat -v
 ## Merge with upstream
 
 Then merge with the forked up-to-date `beta` (default branch):
-
 
 ```shell
 git merge origin/main --no-ff -v
@@ -92,7 +54,6 @@ It will look like this:
 ## Resolve conflicts
 
 Since this pull request does not modify the `package.json` file it is safe to fast forward the changes from `origin/main`:
-
 
 ```shell
 # overwrite with origin/main changes
@@ -153,8 +114,9 @@ And it's ready to merge:
 When dealing with dependency and lock file updates there are multiple use cases to consider, however as a baseline, the OpenSauced triage team will not prioritize parallel main features as seen in the roadmap.
 
 However when that happens, it is advised to:
-- fast-forward `npm-shrinkwrap.json` 
-- fast-forward deleted and modified `upstream/beta` changes to `package.json` 
+
+- fast-forward `npm-shrinkwrap.json`
+- fast-forward deleted and modified `upstream/beta` changes to `package.json`
 - fast-forward your added lines to `package.json`
 - run `npm ci` to delete local modules and create dependency resolution from `upstream/beta`
 

--- a/docs/technical/setup-repo-with-git.md
+++ b/docs/technical/setup-repo-with-git.md
@@ -1,0 +1,70 @@
+---
+id: setup-repo-with-git
+title: Setting up a repository with Git and GitHub
+sidebar_label: Setting up a repository with Git and GitHub
+keywords:
+  - Setting up a repository with Git and GitHub
+---
+
+## Using the GitHub CLI
+
+### How to install the GitHub CLI
+
+The [GitHub CLI](https://cli.github.com/) allows you to fork repositories, create issues, pull requests, and more from the command line.
+
+The GitHub CLI can be installed on Mac, Windows or Linux. You can find the complete installation instructions [here](https://github.com/cli/cli#installation).
+
+### How to authenticate with the GitHub CLI
+
+From the terminal, you will need to authenticate with the GitHub CLI. You can do this by running the following command:
+
+```shell
+gh auth login
+```
+
+Follow the on screen prompts to authenticate with the GitHub CLI.
+
+### How to fork and clone a repository with the GitHub CLI
+
+A fork is a copy of a repository and it allows you to freely experiment with changes without affecting the original project.
+
+A clone is a local copy of a repository that includes all the files, branches, and commits.
+
+To fork and clone a repository with the GitHub CLI, run the following command:
+
+```shell
+gh repo fork open-sauced/REPO_NAME
+```
+
+The GitHub CLI will fork the project in your GitHub account and will ask you if you want to clone the repository on your local machine.
+
+### How to view the remote repositories locally
+
+To view the remote repositories that your local repository is connected to, run the following command:
+
+```shell
+git remote -v
+```
+
+You should see the following output:
+
+```shell
+origin git@github.com:YOUR_GITHUB_USERNAME/open-sauced.git (fetch)
+origin git@github.com:YOUR_GITHUB_USERNAME/open-sauced.git (push)
+upstream git@github.com:open-sauced/open-sauced.git (fetch)
+upstream git@github.com:open-sauced/open-sauced.git (push)
+```
+
+### How to add a remote repository
+
+To pull in changes from the original repository, you will need to add a remote repository. To do this, run the following command:
+
+```shell
+git remote add upstream git@github.com:open-sauced/open-sauced.git
+```
+
+This will allow you to pull in changes from the original repository and keep your forked copy of the repository up to date.
+
+## Using the GitHub website and the command line
+
+If you prefer to setup your repository using the GitHub website and the command line, then you can follow this detailed guide from the [official GitHub documentation](https://docs.github.com/en/get-started/quickstart/fork-a-repo).

--- a/sidebars.js
+++ b/sidebars.js
@@ -41,7 +41,11 @@ module.exports = {
       type: "category",
       label: "Technical guide",
       collapsed: false,
-      items: ["technical/introduction-to-storybook", "technical/resolve-merge-conflicts"],
+      items: [
+        "technical/introduction-to-storybook",
+        "technical/setup-repo-with-git",
+        "technical/resolve-merge-conflicts",
+      ],
     },
     {
       type: "category",
@@ -52,7 +56,7 @@ module.exports = {
         "maintainers/setting-up-a-new-repository",
         "maintainers/check-engines",
         "maintainers/conventional-commit",
-        "maintainers/semantic-release"
+        "maintainers/semantic-release",
       ],
     },
     {


### PR DESCRIPTION
## Description

The following PR is responsible for moving the setting up repo with Git out of the merge conflicts section into its own section.

Now under the Technical Guide section, there is a new section for how to setup a repo with Git, GitHub and GitHub CLI.
I also added some missing setup instructions for the GitHub CLI section so it is more informative for beginners. 



## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
closes #124 

## Mobile & Desktop Screenshots/Recordings
<img width="321" alt="Screenshot 2023-10-09 at 4 48 13 PM" src="https://github.com/open-sauced/docs/assets/67210629/21af95ad-09f0-45dd-bdf1-f9148ba62e3e">

<img width="1176" alt="Screenshot 2023-10-09 at 4 48 35 PM" src="https://github.com/open-sauced/docs/assets/67210629/2dbe53d7-85b5-4ecb-870d-9d841c1e0ce8">




## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [x] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



