### PR TITLE
feat: integrate PostHog for analytics

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -67,9 +67,9 @@ module.exports = {
         },
         {
          to: "community-resources",
-         label: "Community Resources", 
+         label: "Community Resources",
          position: "left"
-        }, 
+        },
       ],
     },
     colorMode: {
@@ -127,7 +127,7 @@ module.exports = {
               label: "Watch our feature demos",
               href: "https://www.youtube.com/playlist?list=PLHyZ0Wz_A44VRlE-YS9me5qxDNRgK5T3H"
              }
-          
+
           ],
         },
       ],
@@ -224,5 +224,12 @@ module.exports = {
         ],
       },
     ],
+    [
+      "posthog-docusaurus",
+      {
+        apiKey: "phc_Uxc9yqu1fvo0DmTMYxWAHUmh8vEzvYcB1UV3xbzUG6I",
+        enableInDevelopment: true
+      }
+    ]
   ],
 };

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -16,6 +16,7 @@
         "@mdx-js/react": "^3.0.0",
         "axios": "^1.7.2",
         "fs": "^0.0.1-security",
+        "posthog-docusaurus": "^2.0.1",
         "prism-react-renderer": "^2.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -16192,6 +16193,14 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+    },
+    "node_modules/posthog-docusaurus": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/posthog-docusaurus/-/posthog-docusaurus-2.0.1.tgz",
+      "integrity": "sha512-MnZvqxvaEt48sUHdz2pvZLKBd8KCXGESq98vTpTSm8uVxtAM3ljc2orZdDErSAKp+WozVEDlQnXTCZ1wzswSYw==",
+      "engines": {
+        "node": ">=10.15.1"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.75.4",
   "private": true,
   "engines": {
-     "node": "^18.17.0 || >=20.5.0",
+    "node": "^18.17.0 || >=20.5.0",
     "npm": ">= 9.6.0"
   },
   "scripts": {
@@ -29,6 +29,7 @@
     "@mdx-js/react": "^3.0.0",
     "axios": "^1.7.2",
     "fs": "^0.0.1-security",
+    "posthog-docusaurus": "^2.0.1",
     "prism-react-renderer": "^2.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"


### PR DESCRIPTION
## Description

Integrates PostHog into the docs using the `posthog-docusaurus` plugin to get autocapture events and analytics.
<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets & Documents

Closes #380 
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Steps to QA

1. Go throughout different pages in the docs
2. Go to PostHog and into the 'Docs' projects
3. See that your navigation on the pages are captured as an event
<!-- 
Please provide some steps for the reviewer to test your change. If you have wrote tests, you can mention that here instead.

1. Click a link
4. Do this thing
5. Validate you see the thing working
-->


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
